### PR TITLE
Added new DC 'hil' Hillsboro, Oregon

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ You can specify any number of worker node pools for example to have mixed nodes 
 workloads.
 
 At the moment Hetzner Cloud has four locations: two in Germany (`nbg1`, Nuremberg and `fsn1`, Falkenstein), one in
-Finland (`hel1`, Helsinki) and one in the USA (`ash`, Ashburn, Virginia). Please note that the Ashburn, Virginia
+Finland (`hel1`, Helsinki) and two in the USA (`ash`, Ashburn, Virginia and `hil`, Hillsboro, Oregon). Please note that the Ashburn, Virginia
 location has just been announced and it's limited to AMD instances for now.
 
 For the available instance types and their specs, either check from inside a project when adding a server manually or

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	SSHAllowedNetworks                []string           `mapstructure:"ssh_allowed_networks" validate:"omitempty,dive,required,cidr"`
 	APIAllowedNetworks                []string           `mapstructure:"api_allowed_networks" validate:"omitempty,dive,cidr"`
 	VerifyHostKey                     bool               `mapstructure:"verify_host_key" validate:"-"`
-	Location                          string             `mapstructure:"location" validate:"required,oneof=nbg1 fsn1 hel1 ash"`
+	Location                          string             `mapstructure:"location" validate:"required,oneof=nbg1 fsn1 hel1 ash hil"`
 	ScheduleWorkloadsOnMasters        bool               `mapstructure:"schedule_workloads_on_masters" validate:"-"`
 	Masters                           MasterConfig       `mapstructure:"masters" validate:"required,dive"`
 	WorkerNodePools                   []WorkerConfig     `mapstructure:"worker_node_pools" validate:"dive"`
@@ -56,7 +56,7 @@ type WorkerConfig struct {
 	Name          string `mapstructure:"name" validate:"required"`
 	InstanceType  string `mapstructure:"instance_type" validate:"required"`
 	InstanceCount int    `mapstructure:"instance_count" validate:"gt=0,required"`
-	Location      string `mapstructure:"location" validate:"omitempty,oneof=nbg1 fsn1 hel1 ash"`
+	Location      string `mapstructure:"location" validate:"omitempty,oneof=nbg1 fsn1 hel1 ash hil"`
 }
 
 type AutoscalerConfig struct {
@@ -64,7 +64,7 @@ type AutoscalerConfig struct {
 	InstanceType string `mapstructure:"instance_type" validate:"required"`
 	InstanceMin  int    `mapstructure:"instance_min" validate:"omitempty,gte=0,required"`
 	InstanceMax  int    `mapstructure:"instance_max" validate:"gt=0,gtefield=InstanceMin,required"`
-	Location     string `mapstructure:"location" validate:"omitempty,oneof=nbg1 fsn1 hel1 ash"`
+	Location     string `mapstructure:"location" validate:"omitempty,oneof=nbg1 fsn1 hel1 ash hil"`
 }
 
 func InitViper() {

--- a/internal/k3s/cluster.go
+++ b/internal/k3s/cluster.go
@@ -823,6 +823,8 @@ func (c *Client) clusterNetworkZone() string {
 
 	if c.location() == "ash" {
 		c.cluster.ClusterNetworkZone = "us-east"
+	} else if c.location() == "hil" {
+		c.cluster.ClusterNetworkZone = "us-west"
 	} else {
 		c.cluster.ClusterNetworkZone = "eu-central"
 	}

--- a/internal/k3s/validation.go
+++ b/internal/k3s/validation.go
@@ -273,7 +273,8 @@ func (c *Client) validateMasterLocation() error {
 			"invalid location for master nodes - "+
 				"valid locations: nbg1 (Nuremberg, Germany), "+
 				"fsn1 (Falkenstein, Germany), hel1 (Helsinki, "+
-				"Finland) or ash (Ashburn, Virginia, USA): %w",
+				"Finland), ash (Ashburn, Virginia, USA) "+
+				"or hil (Hillsboro, Oregon, USA) (H: %w",
 			err,
 		)
 	}


### PR DESCRIPTION
Hetzner Cloud announced the new Hillsboro data center on December 5, 2022. I added the `hil` option to hetzner-k3s and made sure that the network is created in the new `us-west` region.

I also successfully tested creating a cluster in Hillsboro with this change.