### PR TITLE
[bugfix] wrong instance type on create worker node definition

### DIFF
--- a/internal/k3s/cluster.go
+++ b/internal/k3s/cluster.go
@@ -313,7 +313,7 @@ func (c *Client) workerNodePoolDefinitions(workerNodePool *configpkg.WorkerConfi
 					"%s-%s-pool-%s-worker%d", c.clusterName(), workerNodePool.InstanceType,
 					workerNodePool.Name, i+1,
 				),
-				ServerType: &hcloud.ServerType{Name: c.masterInstanceType()},
+				ServerType: &hcloud.ServerType{Name: workerNodePool.InstanceType},
 				SSHKeys:    []*hcloud.SSHKey{c.sshKey()},
 				Networks:   []*hcloud.Network{c.network()},
 				Firewalls:  []*hcloud.ServerCreateFirewall{{Firewall: *c.firewall()}},


### PR DESCRIPTION
When defining the worker node, the server type is set to the  value of server type of the worker master definition 